### PR TITLE
Fix bitwise operation in root key generation

### DIFF
--- a/lib/src/bip32_ed25519/ed25519_bip32.dart
+++ b/lib/src/bip32_ed25519/ed25519_bip32.dart
@@ -73,7 +73,7 @@ class Bip32Ed25519 extends Bip32Ed25519KeyDerivation with Bip32KeyTree {
   Bip32Key master(Uint8List seed) {
     final secretBytes = Hash.sha512(seed);
 
-    if ((secretBytes[31] &= 0x20) != 0) {
+    if ((secretBytes[31] & 0x20) != 0) {
       throw InvalidBip32Ed25519MasterSecretException();
     }
 


### PR DESCRIPTION
In the `master` method it is checked if the third-highest bit of the 32nd byte is set, see [line 76](https://github.com/ilap/bip32-ed25519-dart/blob/99ab9de3eee35213a38285daa598c9a4d2e1f79b/lib/src/bip32_ed25519/ed25519_bip32.dart#L76). The relevant code uses bitwise assignment `&=`:

```dart
if ((secretBytes[31] &= 0x20) != 0) {
    throw InvalidBip32Ed25519MasterSecretException();
}
```

This effectively sets the 32nd byte to `0x20` if the third-highest bit is set and to `0x00` otherwise. In the desired case (the third-highest bit is zero), the entire 32nd byte is cleared, which is not desired according to the [underlying paper](https://acrobat.adobe.com/id/urn:aaid:sc:EU:04fe29b0-ea1a-478b-a886-9bb558a5242a) (see Section V.A).

Replacing the bitwise assignment with a simple bitwise `&` fixes this:

```dart
if ((secretBytes[31] & 0x20) != 0) {
    throw InvalidBip32Ed25519MasterSecretException();
}
```
